### PR TITLE
Add PromptFlow toggle

### DIFF
--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -22,6 +22,7 @@ from constants import USER_AGENT
 from multimodalrag import MultimodalRag
 from data_model import DocumentPerChunkDataModel
 from citation_file_handler import CitationFilesHandler
+from prompt_flow_client import PromptFlowClient
 
 # Load environment variables from .env file
 load_dotenv()
@@ -109,6 +110,8 @@ async def create_app():
         os.environ["ARTIFACTS_STORAGE_CONTAINER"]
     )
 
+    prompt_flow_client = PromptFlowClient()
+
     app = web.Application(middlewares=[])
 
     mmrag = MultimodalRag(
@@ -117,6 +120,7 @@ async def create_app():
         openai_client,
         chatcompletions_model_name,
         artifacts_container_client,
+        prompt_flow_client,
     )
     mmrag.attach_to_app(app, "/chat")
 

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -10,6 +10,7 @@ class SearchConfig(TypedDict):
     use_semantic_ranker: bool = False
     use_streaming: bool = False
     use_knowledge_agent: bool = False
+    use_prompt_flow: bool = False
 
 
 class SearchRequestParameters(TypedDict):

--- a/src/backend/multimodalrag.py
+++ b/src/backend/multimodalrag.py
@@ -13,6 +13,7 @@ from helpers import get_blob_as_base64
 from search_grounding import SearchGroundingRetriever
 from rag_base import RagBase
 from data_model import DataModel
+from prompt_flow_client import PromptFlowClient
 from prompts import (
     SYSTEM_PROMPT_NO_META_DATA,
 )
@@ -32,10 +33,12 @@ class MultimodalRag(RagBase):
         openai_client: AsyncAzureOpenAI,
         chatcompletions_model_name: str,
         container_client: ContainerClient,
+        prompt_flow_client: PromptFlowClient = None,
     ):
         super().__init__(
             openai_client,
             chatcompletions_model_name,
+            prompt_flow_client,
         )
         self.container_client = container_client
         self.blob_service_client = container_client._get_blob_service_client()

--- a/src/frontend/src/components/SearchSettings.tsx
+++ b/src/frontend/src/components/SearchSettings.tsx
@@ -16,6 +16,7 @@ export interface SearchConfig {
     openai_api_mode: OpenAIAPIMode;
     use_streaming: boolean;
     use_knowledge_agent: boolean;
+    use_prompt_flow: boolean;
 }
 
 const SearchSettings: React.FC<Props> = ({ config, setConfig }) => {
@@ -75,6 +76,12 @@ const SearchSettings: React.FC<Props> = ({ config, setConfig }) => {
                 checked={config.use_streaming}
                 onChange={(_, data: SwitchOnChangeData) => handleSwitchChange("use_streaming", data.checked)}
                 label={"Use Streaming Response"}
+            />
+            <Switch
+                id="usePromptFlowSwitch"
+                checked={config.use_prompt_flow}
+                onChange={(_, data: SwitchOnChangeData) => handleSwitchChange("use_prompt_flow", data.checked)}
+                label={<InfoLabel label={"Use Prompt Flow"} info={<>Invoke Prompt Flow for response generation</>} />}
             />
         </div>
     );

--- a/src/frontend/src/hooks/useConfig.tsx
+++ b/src/frontend/src/hooks/useConfig.tsx
@@ -9,7 +9,8 @@ export default function useConfig() {
         chunk_count: 10,
         openai_api_mode: OpenAIAPIMode.ChatCompletions,
         use_streaming: true,
-        use_knowledge_agent: false
+        use_knowledge_agent: false,
+        use_prompt_flow: false
     });
 
     const [indexes, setIndexes] = useState<string[]>([]);


### PR DESCRIPTION
## Summary
- add `use_prompt_flow` option to backend search config
- use PromptFlow client when enabled
- wire PromptFlow client in backend app
- expose PromptFlow switch in UI and default configuration

## Testing
- `npm test` *(fails: missing test script)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*


------
https://chatgpt.com/codex/tasks/task_b_683bfe06e680832dbfb37aa4f72969ae